### PR TITLE
Add login command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/coverage/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5% # allow project coverage to drop by 5% before failing CI checks
+    patch:
+      default:
+        target: 0% # test coverage is not required for a pull request

--- a/src/arguments/email.js
+++ b/src/arguments/email.js
@@ -1,0 +1,19 @@
+const {flags} = require('@oclif/command')
+
+module.exports = {
+  name: 'email',
+  message: 'Please enter your email address',
+  flag: flags.string({char: 'e', description: 'Your accounts email address'}),
+
+  /**
+   * @param {string} email The user provided email address
+   * @returns {boolean} If the email address given is valid
+   */
+  validate(email) {
+    if (email.match(/[^@]+@[^@]+/)) {
+      return true
+    }
+
+    return 'The provided email was invalid'
+  },
+}

--- a/src/arguments/password.js
+++ b/src/arguments/password.js
@@ -1,0 +1,21 @@
+const {flags} = require('@oclif/command')
+
+module.exports = {
+  name: 'password',
+  type: 'password',
+  mask: '*',
+  message: 'Enter a password',
+  flag: flags.string({char: 'p', description: 'The password to login with'}),
+
+  /**
+   * @param {string} password The user provided password
+   * @returns {boolean} If the password is valid
+   */
+  validate(password) {
+    if (password.length >= 8) {
+      return true
+    }
+
+    return 'Your password must be at least 8 characters'
+  },
+}

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,0 +1,80 @@
+const fs = require('fs')
+const homedir = require('os').homedir()
+const {Command} = require('@oclif/command')
+const got = require('got')
+const ora = require('ora')
+const questionHelper = require('../helpers/question-helper')
+const globalFlags = require('../helpers/global-flags')
+const emailArg = require('../arguments/email')
+const passwordArg = require('../arguments/password')
+
+class LoginCommand extends Command {
+  async run() {
+    const filename = `${homedir}${require('path').sep}.checrc`
+    try {
+      fs.accessSync(homedir)
+      fs.closeSync(fs.openSync(filename, 'a'))
+    } catch (error) {
+      return this.error(`The login command requires a writable home directory (using "${homedir}")`)
+    }
+
+    const {flags} = this.parse(LoginCommand)
+
+    const response = await this.login(flags)
+    const key = JSON.parse(response.body).find(candidate => candidate.type === 'secret' && !candidate.is_sandbox)
+
+    if (!key) {
+      return this.error('An unexpected error occured (MISSING_KEY)')
+    }
+
+    fs.writeFileSync(filename, key.key)
+  }
+
+  async login(input = {}) {
+    const {flags: {domain}} = this.parse(LoginCommand)
+    let {email, password} = await questionHelper.ask([emailArg, passwordArg], input)
+
+    const spinner = ora({
+      text: 'Logging into Chec.io...',
+      stream: process.stdout,
+    }).start()
+
+    const urlParams = `email=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}`
+
+    try {
+      const response = await got(`http://api.${domain}/v1/developer/login/issue-keys?${urlParams}`)
+      spinner.succeed('Login successful!')
+      return response
+    } catch (error) {
+      if (!error.response) {
+        spinner.fail('Login failed!')
+        return this.error(`An unexpected error occured (${error.code || error.name})`)
+      }
+
+      const {statusCode} = error.response
+
+      // 404 is no user was found matchiing th credentials
+      if (statusCode !== 404) {
+        spinner.fail('Login failed!')
+        return this.error(`An unexpected error occured (${statusCode})`)
+      }
+    }
+
+    spinner.fail('No user could be found matching the given credentials')
+
+    return this.login()
+  }
+}
+
+LoginCommand.description = `Log into your Chec.io account
+Log into your Chec.io account to enable commands that require API access.
+`
+
+LoginCommand.flags = {
+  email: emailArg.flag,
+  password: passwordArg.flag,
+  ...globalFlags,
+}
+
+module.exports = LoginCommand
+

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -1,0 +1,15 @@
+const {Command} = require('@oclif/command')
+const loginHelper = require('../helpers/login-helper')
+
+class LogoutCommand extends Command {
+  async run() {
+    // Blank out the key to force a logout
+    loginHelper.setLoggedInKey('')
+    this.log('Successfully logged out from Chec.io')
+  }
+}
+
+LogoutCommand.description = `Log into your Chec.io account
+Log into your Chec.io account to enable commands that require API access.
+`
+module.exports = LogoutCommand

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -1,40 +1,21 @@
-const {Command, flags} = require('@oclif/command')
-const inquirer = require('inquirer')
-const questionHelper = require('../helpers/question-helper')
+const {Command} = require('@oclif/command')
 const got = require('got')
 const ora = require('ora')
 const chalk = require('chalk')
 const {cli} = require('cli-ux')
 const process = require('process')
+const globalFlags = require('../helpers/global-flags')
+const questionHelper = require('../helpers/question-helper')
+const emailArg = require('../arguments/email')
+const passwordArg = require('../arguments/password')
 
 class RegisterCommand extends Command {
   async run() {
     const {flags} = this.parse(RegisterCommand)
 
-    const answers = await this.getParameters(flags)
+    const answers = await questionHelper.ask([emailArg, passwordArg], flags)
 
     await this.createMerchant(answers)
-  }
-
-  async getParameters(existingParameters) {
-    const questions = questionHelper.buildQuestions([
-      {
-        name: 'email',
-        validate: this.validateEmail,
-        message: 'Please enter your email address',
-      }, {
-        name: 'password',
-        type: 'password',
-        validate: this.validatePassword,
-        mask: '*',
-        message: 'Enter a password',
-      },
-    ], existingParameters)
-
-    return {
-      ...existingParameters,
-      ...(questions.length > 0 ? await inquirer.prompt(questions) : {}),
-    }
   }
 
   async createMerchant(inputAttributes) {
@@ -43,7 +24,7 @@ class RegisterCommand extends Command {
       text: 'Creating Chec.io account...',
       stream: process.stdout,
     }).start()
-    const {flags: {domain}} = this.parse()
+    const {flags: {domain}} = this.parse(RegisterCommand)
 
     let response
     try {
@@ -92,39 +73,15 @@ class RegisterCommand extends Command {
       }, {})
 
       // Recursively call this method after asking the user for new parameters
-      return this.createMerchant(await this.getParameters(stillValidParameters))
+      return this.createMerchant(await questionHelper.ask([emailArg, passwordArg], stillValidParameters))
     }
 
     spinner.succeed('Account created successfully!')
 
     this.log('Login to your account at:')
-    cli.url(`dashboard.${domain}/login`, 'http://dashboard.chec.local/login')
+    cli.url(`dashboard.${domain}/login`, `https://dashboard.${domain}/login`)
 
     return response
-  }
-
-  /**
-   * @param {string} email The user provided email address
-   * @returns {boolean} If the email address given is valid
-   */
-  validateEmail(email) {
-    if (email.match(/[^@]+@[^@]+/)) {
-      return true
-    }
-
-    return 'The provided email was invalid'
-  }
-
-  /**
-   * @param {string} password The user provided password
-   * @returns {boolean} If the password is valid
-   */
-  validatePassword(password) {
-    if (password.length >= 8) {
-      return true
-    }
-
-    return 'Your password must be at least 8 characters'
   }
 }
 
@@ -133,13 +90,9 @@ Create an account with Chec.io where you can manage products and pricing that is
 `
 
 RegisterCommand.flags = {
-  email: flags.string({char: 'e', description: 'Email address to register with'}),
-  password: flags.string({char: 'p', description: 'Set the password to use when logging in'}),
-  domain: flags.string({
-    hidden: true,
-    description: 'The base URL for the Chec API',
-    default: 'chec.io',
-  }),
+  email: emailArg.flag,
+  password: passwordArg.flag,
+  ...globalFlags,
 }
 
 module.exports = RegisterCommand

--- a/src/helpers/global-flags.js
+++ b/src/helpers/global-flags.js
@@ -1,0 +1,9 @@
+const {flags} = require('@oclif/command')
+
+module.exports = {
+  domain: flags.string({
+    hidden: true,
+    description: 'The base URL for the Chec API',
+    default: 'chec.io',
+  }),
+}

--- a/src/helpers/login-helper.js
+++ b/src/helpers/login-helper.js
@@ -1,0 +1,95 @@
+const fs = require('fs')
+const got = require('got')
+const homedir = require('os').homedir()
+const configFilename = `${homedir}${require('path').sep}.checrc`
+
+class LoginError extends Error {
+  constructor(message, invalid = false) {
+    super(message)
+
+    this.message = message
+    this.invalid = invalid
+  }
+}
+
+module.exports = {
+  /**
+   * Indicates logging in is supported by checking that a dotfile is writable
+   *
+   * @return {boolean} Whether logging in is supported
+   */
+  loginSupported() {
+    try {
+      // Check access
+      fs.accessSync(homedir)
+      // "Touch" the file
+      fs.closeSync(fs.openSync(configFilename, 'a'))
+      return true
+    } catch (error) {
+      return false
+    }
+  },
+
+  /**
+   * Login the user by calling an endpoint and persisting an API key
+   *
+   * @param {string} email The user provided email address
+   * @param {string} password The password for the given email address
+   * @param {string} domain The domain to use for the API endpoint
+   */
+  async login(email, password, domain) {
+    const urlParams = `email=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}`
+    let response
+
+    try {
+      response = await got(`http://api.${domain}/v1/developer/login/issue-keys?${urlParams}`)
+    } catch (error) {
+      if (!error.response) {
+        throw new LoginError(`An unexpected error occured (${error.code || error.name})`)
+      }
+
+      const {statusCode} = error.response
+
+      // 404 is no user was found matching the credentials. If it's not a 404 (or 2xx) then it's unexpected
+      if (statusCode !== 404) {
+        throw new LoginError(`An unexpected error occured (${statusCode})`)
+      }
+
+      throw new LoginError('User not found', true)
+    }
+
+    const key = JSON.parse(response.body).find(candidate => candidate.type === 'secret' && !candidate.is_sandbox)
+
+    if (!key) {
+      throw new LoginError('An unexpected error occured (MISSING_KEY)')
+    }
+
+    // Write the key
+    this.setLoggedInKey(key.key)
+  },
+
+  /**
+   * Set the API key that is persitsted for a logged in user
+   *
+   * @param {string} key The API key to presist
+   */
+  setLoggedInKey(key) {
+    fs.writeFileSync(configFilename, key)
+  },
+
+  /**
+   * Check that the user is logged in by checking that an API key is persisted. Note this doesn't assert the API key
+   * is still valid.
+   *
+   * @return {boolean} Whether the user is considered "logged in"
+   */
+  isLoggedIn() {
+    if (!this.loginSupported()) {
+      return false
+    }
+
+    return fs.readFileSync(configFilename).length > 0
+  },
+
+  configFilename,
+}

--- a/src/helpers/question-helper.js
+++ b/src/helpers/question-helper.js
@@ -1,3 +1,5 @@
+const inquirer = require('inquirer')
+
 module.exports = {
   /**
    * @param {array} questions The question definitions as documented by inquirer
@@ -33,5 +35,18 @@ module.exports = {
         message: `${validationResponse}. ${question.message}`,
       }
     }).filter(question => Boolean(question))
+  },
+
+  async ask(questions, existingValidAnswers) {
+    const newQuestions = this.buildQuestions(questions, existingValidAnswers)
+
+    if (newQuestions.length === 0) {
+      return existingValidAnswers
+    }
+
+    return {
+      ...existingValidAnswers,
+      ...await inquirer.prompt(newQuestions),
+    }
   },
 }

--- a/test/commands/login.test.js
+++ b/test/commands/login.test.js
@@ -1,9 +1,24 @@
+/* global beforeEach afterEach */
+
 const {expect, test} = require('@oclif/test')
 const inquirer = require('inquirer')
 const sinon = require('sinon')
 const fs = require('fs')
+const {configFilename} = require('../../src/helpers/login-helper')
 
 describe('login', () => {
+  let writeFileStub
+  let readFileStub
+  beforeEach(() => {
+    writeFileStub = sinon.stub(fs, 'writeFileSync')
+    readFileStub = sinon.stub(fs, 'readFileSync')
+    readFileStub.callThrough().withArgs(configFilename).returns('')
+  })
+  afterEach(() => {
+    writeFileStub.restore()
+    readFileStub.restore()
+  })
+
   const fakeSuccessfulResponse = JSON.stringify([
     {key: 'pk_test_123', type: 'public', is_sandbox: true}, // eslint-disable-line camelcase
     {key: 'pk_123', type: 'public', is_sandbox: false}, // eslint-disable-line camelcase
@@ -11,12 +26,40 @@ describe('login', () => {
     {key: 'sk_123', type: 'secret', is_sandbox: false}, // eslint-disable-line camelcase
   ])
 
+  test
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    confirm: false,
+  }))
+  .do(() => {
+    readFileStub.withArgs(configFilename).returns('something')
+  })
+  .stdout()
+  .command('login')
+  .it('Will prompt for confirmation if a user is already logged in and exit when told "no"', () => {
+    expect(inquirer.prompt.lastArg[0]).to.include({
+      type: 'confirm',
+      message: 'A user is currently logged in, do you want to continue?',
+    })
+  })
+
   const base = test
   .nock('http://api.chec.io', api => api
   .get('/v1/developer/login/issue-keys?email=test@example.com&password=abcd1234')
   .reply(200, fakeSuccessfulResponse)
   )
   .stdout()
+
+  base
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    confirm: true,
+  }))
+  .do(() => {
+    readFileStub.withArgs(configFilename).returns('something')
+  })
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .it('Will prompt for confirmation if a user is already logged in and continue when told "yes"', ctx => {
+    expect(ctx.stdout).to.contain('Login successful!')
+  })
 
   base
   .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
@@ -86,10 +129,32 @@ describe('login', () => {
   .stub(fs, 'accessSync', () => {
     throw new Error('fail')
   })
-  .stderr()
   .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
   .catch(error => {
     expect(error.message).to.contain('The login command requires a writable home directory')
   })
   .it('Will advise when config is unwritable', () => {})
+
+  test
+  .nock('http://api.chec.io', api => api
+  .get('/v1/developer/login/issue-keys?email=bob%2Bplus@example.com&password=qw3r%2By12')
+  .reply(200, fakeSuccessfulResponse)
+  )
+  .stdout()
+  .command(['login', '-e', 'bob+plus@example.com', '-p', 'qw3r+y12'])
+  .it('will encode url unsafe characters on the request', ctx => {
+    expect(ctx.stdout).to.contain('Login successful!')
+  })
+
+  test
+  .nock('http://api.chec.io', api => api
+  .get('/v1/developer/login/issue-keys?email=test@example.com&password=abcd1234')
+  .reply(200, JSON.stringify([]))
+  )
+  .stdout()
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .catch(error => {
+    expect(error.message).to.contain('An unexpected error occured (MISSING_KEY)')
+  })
+  .it('advises when a valid key was not returned from the API', () => {})
 })

--- a/test/commands/login.test.js
+++ b/test/commands/login.test.js
@@ -1,0 +1,95 @@
+const {expect, test} = require('@oclif/test')
+const inquirer = require('inquirer')
+const sinon = require('sinon')
+const fs = require('fs')
+
+describe('login', () => {
+  const fakeSuccessfulResponse = JSON.stringify([
+    {key: 'pk_test_123', type: 'public', is_sandbox: true}, // eslint-disable-line camelcase
+    {key: 'pk_123', type: 'public', is_sandbox: false}, // eslint-disable-line camelcase
+    {key: 'sk_test_123', type: 'secret', is_sandbox: true}, // eslint-disable-line camelcase
+    {key: 'sk_123', type: 'secret', is_sandbox: false}, // eslint-disable-line camelcase
+  ])
+
+  const base = test
+  .nock('http://api.chec.io', api => api
+  .get('/v1/developer/login/issue-keys?email=test@example.com&password=abcd1234')
+  .reply(200, fakeSuccessfulResponse)
+  )
+  .stdout()
+
+  base
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .it('can login with provided args', ctx => {
+    expect(ctx.stdout).to.contain('Login successful!')
+  })
+
+  base
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    email: 'test@example.com',
+    password: 'abcd1234',
+  }))
+  .command(['login'])
+  .it('prompts for information that is required', ctx => {
+    expect(ctx.stdout).to.contain('Login successful!')
+    expect(inquirer.prompt.calledOnce).to.equal(true)
+    expect(inquirer.prompt.lastArg[0]).to.include({name: 'email', message: 'Please enter your email address'})
+    expect(inquirer.prompt.lastArg[1]).to.include({name: 'password', message: 'Enter a password'})
+  })
+
+  base
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    email: 'test@example.com',
+    password: 'abcd1234',
+  }))
+  .command(['login', '-e', 'bad', '-p', 'bad'])
+  .it('prompts for information if arguments are invalid', () => {
+    expect(inquirer.prompt.calledOnce).to.equal(true)
+    expect(inquirer.prompt.lastArg[0]).to.include({name: 'email', message: 'The provided email was invalid. Please enter your email address'})
+    expect(inquirer.prompt.lastArg[1]).to.include({name: 'password', message: 'Your password must be at least 8 characters. Enter a password'})
+  })
+
+  test
+  .nock('http://api.chec.io', api => api
+  .get('/v1/developer/login/issue-keys?email=test@example.com&password=abcd1234')
+  .reply(500, JSON.stringify({}))
+  )
+  .stdout()
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .catch(error => expect(error.message).to.contain('An unexpected error occured (RequestError)'))
+  .it('gracefully handles non 2xx and 404 responses', ctx => {
+    expect(ctx.stdout).to.not.contain('Login successful!')
+  })
+
+  test
+  .nock('http://api.chec.io', api => api
+  .get('/v1/developer/login/issue-keys?email=test@example.com&password=abcd1234')
+  .reply(404, JSON.stringify({}))
+  .get('/v1/developer/login/issue-keys?email=bob@example.com&password=qw3rty12')
+  .reply(200, fakeSuccessfulResponse)
+  )
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    email: 'bob@example.com',
+    password: 'qw3rty12',
+  }))
+  .stdout()
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .it('gracefully handles 404 responses and continues to prompt user', ctx => {
+    expect(inquirer.prompt.calledOnce).to.equal(true)
+    expect(inquirer.prompt.lastArg).to.have.length(2)
+    expect(inquirer.prompt.lastArg[0]).to.include({name: 'email', message: 'Please enter your email address'})
+    expect(inquirer.prompt.lastArg[1]).to.include({name: 'password', message: 'Enter a password'})
+    expect(ctx.stdout).to.contain('Login successful!')
+  })
+
+  test
+  .stub(fs, 'accessSync', () => {
+    throw new Error('fail')
+  })
+  .stderr()
+  .command(['login', '-e', 'test@example.com', '-p', 'abcd1234'])
+  .catch(error => {
+    expect(error.message).to.contain('The login command requires a writable home directory')
+  })
+  .it('Will advise when config is unwritable', () => {})
+})

--- a/test/commands/logout.test.js
+++ b/test/commands/logout.test.js
@@ -1,0 +1,15 @@
+const {expect, test} = require('@oclif/test')
+const loginHelper = require('../../src/helpers/login-helper')
+const sinon = require('sinon')
+
+describe('logout', () => {
+  test
+  .stub(loginHelper, 'setLoggedInKey', sinon.fake())
+  .stdout()
+  .command(['logout'])
+  .it('blanks out the key and displays a message', ctx => {
+    expect(loginHelper.setLoggedInKey.calledOnce).to.equal(true)
+    expect(loginHelper.setLoggedInKey.lastArg).to.equal('')
+    expect(ctx.stdout).to.contain('Successfully logged out from Chec.io')
+  })
+})

--- a/test/commands/register.test.js
+++ b/test/commands/register.test.js
@@ -68,7 +68,7 @@ describe('register', () => {
   }))
   .stdout()
   .command(['register', '-e', 'test@example.com', '-p', 'abcd1234'])
-  .it('gracefully handles non 2xx and 422 responses', ctx => {
+  .it('gracefully handles 422 responses and continues to prompt user', ctx => {
     expect(inquirer.prompt.calledOnce).to.equal(true)
     expect(inquirer.prompt.lastArg).to.have.length(1)
     expect(inquirer.prompt.lastArg[0]).to.include({name: 'email', message: 'Please enter your email address'})


### PR DESCRIPTION
This allows logging in by using a new API endpoint to exchange a users' credentials for API keys. It will take the non-sandbox "secret" key from the response and persist it in a dotfile in the users home directory. I've done this in what's supposed to be a platform agnostic way, but I don't have a Windows machine to confirm.

- Moves email and password arguments to a new "arguments" folder so they can be reused
- Fixes the name of a register test
- Refactored the question-helper a little to do the asking as well as parsing questions